### PR TITLE
Update keyboard_dismisser.dart

### DIFF
--- a/lib/keyboard_dismisser.dart
+++ b/lib/keyboard_dismisser.dart
@@ -415,7 +415,7 @@ class KeyboardDismisser extends StatelessWidget {
       );
 
   void _unfocus(BuildContext context) =>
-      WidgetsBinding.instance?.focusManager.primaryFocus?.unfocus();
+      WidgetsBinding.instance.focusManager.primaryFocus?.unfocus();
 
   void _unfocusWithDetails(
     BuildContext context,


### PR DESCRIPTION
fix warning G1E0FE241: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.