### PR TITLE
Fix nullable WidgetsBinding property

### DIFF
--- a/lib/keyboard_dismisser.dart
+++ b/lib/keyboard_dismisser.dart
@@ -415,7 +415,7 @@ class KeyboardDismisser extends StatelessWidget {
       );
 
   void _unfocus(BuildContext context) =>
-      WidgetsBinding.instance.focusManager.primaryFocus?.unfocus();
+      WidgetsBinding.instance?.focusManager.primaryFocus?.unfocus();
 
   void _unfocusWithDetails(
     BuildContext context,


### PR DESCRIPTION
Currently you cannot build a project because of this, have been getting those logs when building ios:

```
../../.pub-cache/hosted/pub.dartlang.org/keyboard_dismisser-3.0.0/lib/keyboard_dismisser.dart:418:31: Error: Property 'focusManager' cannot be accessed on 'WidgetsBinding?' because it is potentially null.
     - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../flutter-sdk/flutter/packages/flutter/lib/src/widgets/binding.dart').
    Try accessing using ?. instead.
          WidgetsBinding.instance.focusManager.primaryFocus?.unfocus();
```